### PR TITLE
DemoApp: Clean up and simplification

### DIFF
--- a/apple/DemoApp/Demo/DemoApp.swift
+++ b/apple/DemoApp/Demo/DemoApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // This AppDelegate setup is an easy way to share your environment with CarPlay
 class DemoAppDelegate: NSObject, UIApplicationDelegate {
-    let appEnvironment = AppEnvironment()
+    let appEnvironment = try! AppEnvironment()
 }
 
 @main


### PR DESCRIPTION
- Also Initialize FerrostarCore via an extension to encapsulate details
- Use `try!` at the last possible moment and let the intervening items `throw`.
- use an extension to create the `SimulatedLocationProvider`
- Depends upon #541